### PR TITLE
Ensure Windows scripts run from repo directory

### DIFF
--- a/run_app.bat
+++ b/run_app.bat
@@ -1,0 +1,38 @@
+@echo off
+PUSHD "%~dp0"
+
+SET "EXIT_CODE=0"
+SET "APP_PUSHED="
+
+IF NOT EXIST ".venv\Scripts\activate.bat" (
+    echo Virtual environment not found. Please run setup_env.bat first.
+    SET "EXIT_CODE=1"
+    GOTO error
+)
+
+call .venv\Scripts\activate
+IF ERRORLEVEL 1 (
+    SET "EXIT_CODE=%ERRORLEVEL%"
+    GOTO error
+)
+
+IF EXIST app (
+    PUSHD app
+    SET "APP_PUSHED=1"
+)
+
+python main.py
+SET "EXIT_CODE=%ERRORLEVEL%"
+IF NOT "%EXIT_CODE%"=="0" GOTO error
+
+IF DEFINED APP_PUSHED POPD
+POPD
+EXIT /B 0
+
+:error
+echo.
+echo Failed to launch the application.
+IF DEFINED APP_PUSHED POPD
+POPD
+PAUSE
+EXIT /B %EXIT_CODE%

--- a/setup_env.bat
+++ b/setup_env.bat
@@ -1,0 +1,30 @@
+@echo off
+PUSHD "%~dp0"
+
+REM Create a virtual environment called ".venv"
+python -m venv .venv
+IF ERRORLEVEL 1 GOTO error
+
+REM Activate the virtual environment (Windows)
+call .venv\Scripts\activate
+IF ERRORLEVEL 1 GOTO error
+
+REM Install dependencies
+pip install -r requirements.txt
+IF ERRORLEVEL 1 GOTO error
+
+echo.
+echo Virtual environment created and dependencies installed.
+echo To run the script, use "run_app.bat"
+POPD
+GOTO end
+
+:error
+echo.
+echo Failed to set up the environment. Please review the messages above.
+POPD
+PAUSE
+EXIT /B 1
+
+:end
+EXIT /B 0


### PR DESCRIPTION
## Summary
- ensure the Windows helper scripts switch to the repository directory before running commands
- keep failures visible by leaving the console window open when setup or launch errors occur

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce99c2761c832d9e5b1a8d334b4cd8